### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@
 
 name: Node.js CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Voodoo262/cloudflare-access-proxy/security/code-scanning/1](https://github.com/Voodoo262/cloudflare-access-proxy/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only performs read operations (e.g., checking out the repository and installing dependencies), we will set `contents: read` as the minimal required permission. This ensures the workflow has only the permissions it needs to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
